### PR TITLE
Update tbex-addons.php

### DIFF
--- a/includes/admin/tbex-addons.php
+++ b/includes/admin/tbex-addons.php
@@ -93,8 +93,8 @@ function ddw_tbex_get_addons_type( $type = '' ) {
 					continue;
 				}
 
-				$addons_{$type}[ $addon ] = $addon_data;
-				$addons_by_type = $addons_{$type};
+				$addons_[$type][ $addon ] = $addon_data;
+				$addons_by_type = $addons_[$type];
 
 			}  // end if
 


### PR DESCRIPTION
Line 96-97 Fixes "Array and string offset access syntax with curly braces is deprecated" on php 7.4